### PR TITLE
Remove deprecated declarations for homebrew-tools

### DIFF
--- a/gort.rb
+++ b/gort.rb
@@ -3,13 +3,9 @@ class Gort < Formula
   homepage "http://gort.io/"
   version "0.9.0"
 
-  if MacOS.prefer_64_bit?
-    url "https://s3.amazonaws.com/gort-io/0.9.0/gort_0.9.0_darwin_amd64.zip"
-    sha256 "744fb23c83b1c5ac8612f08c3c9f791ad12a2bef0a9d0b79eb695da6a124025b"
-  else
-    url "https://s3.amazonaws.com/gort-io/0.9.0/gort_0.9.0_darwin_386.zip"
-    sha256 "56c2e2621d69501eb230514cb93deaca8bf26d86c1f8d821af3719e5a03076dd"
-  end
+  url "https://s3.amazonaws.com/gort-io/0.9.0/gort_0.9.0_darwin_amd64.zip"
+  sha256 "744fb23c83b1c5ac8612f08c3c9f791ad12a2bef0a9d0b79eb695da6a124025b"
+  
 
   bottle :unneeded
 

--- a/opencv.rb
+++ b/opencv.rb
@@ -27,10 +27,7 @@ class Opencv < Formula
     sha256 "4fb0681414df4baedce6e3f4a01318d6f4fcde6ee14854d761fd4e397a397763"
   end
 
-  needs :cxx11
-
   def install
-    ENV.cxx11
 
     resource("contrib").stage buildpath/"opencv_contrib"
 


### PR DESCRIPTION
## Issue
Removes deprecated declarations in recipies that prevent it from being tapped on in current versions of Homebrew.

The following error is experienced when tapping the Homebrew recipies:
```bash
Error: Calling needs :cxx11 is disabled! There is no replacement.
Calling MacOS.prefer_64_bit? is disabled! There is no replacement.
```

## Homebrew Version Affected
```bash
Homebrew 2.0.0
Homebrew/homebrew-core (git revision dd6c6; last commit 2019-02-03)
Homebrew/homebrew-cask (git revision 8ab02; last commit 2019-02-03)
```

## Resolution
Remove the call to :cxx11 and MacOS.prefer_64_bit to remove the errors.

Resolves #4 